### PR TITLE
Show only existing pools owned by connected wallet

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -22,7 +22,7 @@ function Footer() {
           </div>
         </div>
         <div className="text-0.6875 text-medium">
-          Bootstrapped and open-sourced from Australia. <span>Copyright 2022.</span>
+          Bootstrapped and open-sourced from Australia. <span>Copyright 2023.</span>
         </div>
       </div>
       <div className="flex">

--- a/src/hooks/usePoolsForNetwork.ts
+++ b/src/hooks/usePoolsForNetwork.ts
@@ -40,12 +40,13 @@ function reconcileTransactions(chainId: number, txs: any[]) {
   });
 }
 
-export function usePoolsForNetwork(chainId: number, timestamp: number) {
-  const { addresses } = useAddress();
+// set `onlyForInjected`to return pools owned by connected wallet
+export function usePoolsForNetwork(chainId: number, timestamp: number, onlyForInjected = false) {
+  const { addresses: inputAddresses, injectedAddress } = useAddress();
 
   const { loading: queryLoading, positionStates: allPositions } = useFetchPositions(
     chainId,
-    addresses,
+    onlyForInjected ? [injectedAddress] : inputAddresses,
     timestamp,
   );
 

--- a/src/pages/add/index.tsx
+++ b/src/pages/add/index.tsx
@@ -25,7 +25,8 @@ function AddLiquidity() {
   // keep timestamp static
   // This page ends up being re-rendered this prevents it
   const timestamp = 1234;
-  const { pools } = usePoolsForNetwork(chainId || 1, timestamp);
+  const onlyForInjected = true;
+  const { pools } = usePoolsForNetwork(chainId || 1, timestamp, onlyForInjected);
 
   const [tokens, setTokens] = useState<TokenListItem[]>([]);
   const [selectedBaseToken, setSelectedBaseToken] = useState<Token | null>(null);


### PR DESCRIPTION
This prevents showing existing positions from input addresses.